### PR TITLE
sort option persists

### DIFF
--- a/src/LibraryWidget.tsx
+++ b/src/LibraryWidget.tsx
@@ -32,8 +32,10 @@ function Library({ templates, snippets, deleteTemplate, renameTemplate, editTemp
   const [editingId, setEditingId] = useState<string | null>(null);
   const [newContent, setNewContent] = useState<string>("");
 
+  // sort by last used sort option (or created-desc if none)
+  const initialSortOption = localStorage.getItem("sortOption") || "created-desc";
+  const [sortOption, setSortOption] = useState(initialSortOption);
   const [sortedTemplates, setSortedTemplates] = useState<Template[]>(templates);
-  const [sortOption, setSortOption] = useState<string>('created-desc'); // Default to sort by most recently created
 
   const toggleTemplate = (id: string) => {
     setExpandedTemplates((prev) => ({
@@ -88,6 +90,11 @@ function Library({ templates, snippets, deleteTemplate, renameTemplate, editTemp
       return changed ? updated : prev;
     });
   }, [templates])
+
+  // When the sort option is updated, save to local storage
+  React.useEffect(() => {
+    localStorage.setItem("sortOption", sortOption);
+  }, [sortOption]);
 
   /** 
   React.useEffect(() => {


### PR DESCRIPTION
# Pull Request Template
Pulled template from [here](https://bepieter.medium.com/cracking-github-pr-templates-your-guide-to-skyrocketing-collaboration-bef3d5659241)

## Added persistence for sorting option

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
LibraryWidget.tsx : added to Library function an initialSortOption const that accesses localStorage and added a useEffect to update the localStorage whenever the sortOption changes

## Testing
Tested the extension

## Impact
Just affects the sorting of templates on load

## Additional Information

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings 
