### PR TITLE
36 decoration toggle

### DIFF
--- a/src/CodeMirrorPlugin.ts
+++ b/src/CodeMirrorPlugin.ts
@@ -52,14 +52,13 @@ export function CodeMirrorExtension(snippetsManager: SnippetsManager): Extension
     });
 
     // This event listener will now be registered only once
-    document.addEventListener('Save Code Snippet', (event) => {
+   document.addEventListener('Save Code Snippet', (event) => {
       const templateID = (event as CustomEvent).detail.templateID;
       
       if (!currentView) {
         console.warn("No active editor view available");
         return;
       }
-      
       const selection = currentView.state.selection.main;
       const startLine = currentView.state.doc.lineAt(selection.from).number;
       const endLine = currentView.state.doc.lineAt(selection.to).number;
@@ -71,15 +70,16 @@ export function CodeMirrorExtension(snippetsManager: SnippetsManager): Extension
         console.warn("Skipping empty snippet");
         return; // Do not create an empty snippet
       }
-      
+     
+      console.log("Decorations should be addedddd");
+      //Issue here because of design its not being applied 
       //Have to do an automatic refresh to reapply the decorations
       setTimeout(() => {
         snippetsManager.update(currentView!);
         snippetsManager.create(currentView!, startLine, endLine, templateID, droppedText);
-        currentView!.dispatch({ effects: [] });
+        snippetsManager.assignDecorations(currentView!);
       }, 10);
-      // Update decorations through the plugin instance rather than directly here
-      // The ViewPlugin's update method will handle that
+
     });
   }
   

--- a/src/CodeMirrorPlugin.ts
+++ b/src/CodeMirrorPlugin.ts
@@ -93,7 +93,9 @@ export function CodeMirrorExtension(snippetsManager: SnippetsManager): Extension
         console.warn("Skipping empty snippet");
         return; // Do not create an empty snippet
       }
-      
+     
+      console.log("Decorations should be addedddd");
+      //Issue here because of design its not being applied 
       //Have to do an automatic refresh to reapply the decorations
       setTimeout(() => {
         snippetsManager.update(currentView!);

--- a/src/CodeMirrorPlugin.ts
+++ b/src/CodeMirrorPlugin.ts
@@ -28,6 +28,29 @@ export function CodeMirrorExtension(snippetsManager: SnippetsManager): Extension
   if (!saveSnippetListenerRegistered) {
     saveSnippetListenerRegistered = true;
     
+    document.addEventListener('TemplateDeleted', (event: Event) => {
+      if (!currentView) {
+        console.warn("No active editor view available");
+        return;
+      }
+      // Update decorations
+      currentView.dispatch({
+        effects: [] 
+      });
+  });
+  
+    document.addEventListener('Toggle Template Highlight', (event) => {
+      if (!currentView) {
+        console.warn("No active editor view available");
+        return;
+      }
+      // Force the view to update which will trigger the update method
+      // where decorations are refreshed
+      currentView.dispatch({
+        effects: [], // Empty transaction to trigger an update
+      });
+    });
+
     // This event listener will now be registered only once
     document.addEventListener('Save Code Snippet', (event) => {
       const templateID = (event as CustomEvent).detail.templateID;
@@ -48,8 +71,7 @@ export function CodeMirrorExtension(snippetsManager: SnippetsManager): Extension
         console.warn("Skipping empty snippet");
         return; // Do not create an empty snippet
       }
-     
-      //Issue here because of design its not being applied 
+      
       //Have to do an automatic refresh to reapply the decorations
       setTimeout(() => {
         snippetsManager.update(currentView!);

--- a/src/CodeMirrorPlugin.ts
+++ b/src/CodeMirrorPlugin.ts
@@ -51,6 +51,29 @@ export function CodeMirrorExtension(snippetsManager: SnippetsManager): Extension
       });
     });
 
+    document.addEventListener('TemplateDeleted', (event: Event) => {
+      if (!currentView) {
+        console.warn("No active editor view available");
+        return;
+      }
+      // Update decorations
+      currentView.dispatch({
+        effects: [] 
+      });
+  });
+  
+    document.addEventListener('Toggle Template Highlight', (event) => {
+      if (!currentView) {
+        console.warn("No active editor view available");
+        return;
+      }
+      // Force the view to update which will trigger the update method
+      // where decorations are refreshed
+      currentView.dispatch({
+        effects: [], // Empty transaction to trigger an update
+      });
+    });
+
     // This event listener will now be registered only once
    document.addEventListener('Save Code Snippet', (event) => {
       const templateID = (event as CustomEvent).detail.templateID;
@@ -70,9 +93,7 @@ export function CodeMirrorExtension(snippetsManager: SnippetsManager): Extension
         console.warn("Skipping empty snippet");
         return; // Do not create an empty snippet
       }
-     
-      console.log("Decorations should be addedddd");
-      //Issue here because of design its not being applied 
+      
       //Have to do an automatic refresh to reapply the decorations
       setTimeout(() => {
         snippetsManager.update(currentView!);

--- a/src/LibraryWidget.tsx
+++ b/src/LibraryWidget.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/quotes */
+/* eslint-disable prettier/prettier */
 import { ReactWidget } from '@jupyterlab/ui-components';
 import * as React from 'react';
 import { useState } from 'react';
@@ -18,12 +20,14 @@ import { SnippetsManager } from './snippetManager';
 /**
  * React Library Component.
  */
-function Library({ templates, snippets, deleteTemplate, renameTemplate, editTemplate }: {
+function Library({ templates, snippets, deleteTemplate, renameTemplate, editTemplate,toggleTemplateColor,activeTemplateHighlightIds }: {
     templates: Template[],
     snippets: Snippet[],
     deleteTemplate : (id : string, name : string) => void,
     renameTemplate : (id : string, name : string) => void,
     editTemplate : (id : string, name : string) => void,
+    toggleTemplateColor : (id : string) => void,
+    activeTemplateHighlightIds: Set<string>,
   }) {
     console.log("Library received templates:", templates);
   const [expandedTemplates, setExpandedTemplates] = useState<{ [key: string]: boolean }>({});
@@ -212,6 +216,19 @@ function Library({ templates, snippets, deleteTemplate, renameTemplate, editTemp
                 )}
 
                 <div className="template-buttons">
+
+                 <button 
+                    className={`template-toggle ${activeTemplateHighlightIds.has(template.id) ? 'template-highlight-active' : ''}`}
+                    title={activeTemplateHighlightIds.has(template.id) ? "Hide highlights" : "Show highlights"} 
+                    onClick={() => {
+                      toggleTemplateColor(template.id);
+                    }}
+                  >
+                    <span style={{ 
+                      color: activeTemplateHighlightIds.has(template.id) ? template.color : 'gray' 
+                    }}>▣</span>
+                  </button>
+
                   <button className="template-copy" title="Copy to clipboard" onClick={() => handleCopy(template)}>
                     <copyIcon.react tag="span" height="16px" width="16px" />
                   </button>
@@ -301,9 +318,11 @@ export class LibraryWidget extends ReactWidget {
     this.loadTemplates();
   }
 
-  createTemplate(codeSnippet: string) {
-    this.templateManager.create(codeSnippet);
+  //CHANGED THIS
+  async createTemplate(codeSnippet: string) {
+    await this.templateManager.loadTemplates();
     this.update();
+    return await this.templateManager.create(codeSnippet);
   }
 
   deleteTemplate = (id: string, name: string) => {
@@ -321,8 +340,13 @@ export class LibraryWidget extends ReactWidget {
     this.update();
   }
 
-  loadTemplates() {
-    this.templateManager.loadTemplates();
+  toggleTemplateColor = (id: string) => {
+    this.templateManager.toggleTemplateColor(id);
+    this.update();
+  }
+
+  async loadTemplates() {
+    await this.templateManager.loadTemplates();
     this.update();
   }
 
@@ -334,6 +358,8 @@ export class LibraryWidget extends ReactWidget {
       deleteTemplate={this.deleteTemplate}
       renameTemplate={this.renameTemplate}
       editTemplate={this.editTemplate}
+       toggleTemplateColor={this.toggleTemplateColor}
+      activeTemplateHighlightIds={this.templateManager.activeTemplateHighlightIds}
       />;
   }
 }

--- a/src/LibraryWidget.tsx
+++ b/src/LibraryWidget.tsx
@@ -318,9 +318,11 @@ export class LibraryWidget extends ReactWidget {
     this.loadTemplates();
   }
 
+  //CHANGED THIS
   createTemplate(codeSnippet: string) {
     this.update();
     return this.templateManager.create(codeSnippet);
+
   }
 
   deleteTemplate = (id: string, name: string) => {
@@ -343,6 +345,7 @@ export class LibraryWidget extends ReactWidget {
     this.update();
   }
 
+
   loadTemplates() {
     this.templateManager.loadTemplates();
     this.update();
@@ -356,7 +359,7 @@ export class LibraryWidget extends ReactWidget {
       deleteTemplate={this.deleteTemplate}
       renameTemplate={this.renameTemplate}
       editTemplate={this.editTemplate}
-      toggleTemplateColor={this.toggleTemplateColor}
+       toggleTemplateColor={this.toggleTemplateColor}
       activeTemplateHighlightIds={this.templateManager.activeTemplateHighlightIds}
       />;
   }

--- a/src/LibraryWidget.tsx
+++ b/src/LibraryWidget.tsx
@@ -318,11 +318,9 @@ export class LibraryWidget extends ReactWidget {
     this.loadTemplates();
   }
 
-  //CHANGED THIS
-  async createTemplate(codeSnippet: string) {
-    await this.templateManager.loadTemplates();
+  createTemplate(codeSnippet: string) {
     this.update();
-    return await this.templateManager.create(codeSnippet);
+    return this.templateManager.create(codeSnippet);
   }
 
   deleteTemplate = (id: string, name: string) => {
@@ -345,8 +343,8 @@ export class LibraryWidget extends ReactWidget {
     this.update();
   }
 
-  async loadTemplates() {
-    await this.templateManager.loadTemplates();
+  loadTemplates() {
+    this.templateManager.loadTemplates();
     this.update();
   }
 
@@ -358,7 +356,7 @@ export class LibraryWidget extends ReactWidget {
       deleteTemplate={this.deleteTemplate}
       renameTemplate={this.renameTemplate}
       editTemplate={this.editTemplate}
-       toggleTemplateColor={this.toggleTemplateColor}
+      toggleTemplateColor={this.toggleTemplateColor}
       activeTemplateHighlightIds={this.templateManager.activeTemplateHighlightIds}
       />;
   }

--- a/src/LibraryWidget.tsx
+++ b/src/LibraryWidget.tsx
@@ -318,11 +318,9 @@ export class LibraryWidget extends ReactWidget {
     this.loadTemplates();
   }
 
-  //CHANGED THIS
   createTemplate(codeSnippet: string) {
     this.update();
     return this.templateManager.create(codeSnippet);
-
   }
 
   deleteTemplate = (id: string, name: string) => {
@@ -345,7 +343,6 @@ export class LibraryWidget extends ReactWidget {
     this.update();
   }
 
-
   loadTemplates() {
     this.templateManager.loadTemplates();
     this.update();
@@ -359,7 +356,7 @@ export class LibraryWidget extends ReactWidget {
       deleteTemplate={this.deleteTemplate}
       renameTemplate={this.renameTemplate}
       editTemplate={this.editTemplate}
-       toggleTemplateColor={this.toggleTemplateColor}
+      toggleTemplateColor={this.toggleTemplateColor}
       activeTemplateHighlightIds={this.templateManager.activeTemplateHighlightIds}
       />;
   }

--- a/src/LibraryWidget.tsx
+++ b/src/LibraryWidget.tsx
@@ -32,8 +32,10 @@ function Library({ templates, snippets, deleteTemplate, renameTemplate, editTemp
   const [editingId, setEditingId] = useState<string | null>(null);
   const [newContent, setNewContent] = useState<string>("");
 
+  // sort by last used sort option (or created-desc if none)
+  const initialSortOption = localStorage.getItem("sortOption") || "created-desc";
+  const [sortOption, setSortOption] = useState(initialSortOption);
   const [sortedTemplates, setSortedTemplates] = useState<Template[]>(templates);
-  const [sortOption, setSortOption] = useState<string>('created-desc'); // Default to sort by most recently created
 
   const toggleTemplate = (id: string) => {
     setExpandedTemplates((prev) => ({
@@ -88,6 +90,11 @@ function Library({ templates, snippets, deleteTemplate, renameTemplate, editTemp
       return changed ? updated : prev;
     });
   }, [templates])
+
+  // When the sort option is updated, save to local storage
+  React.useEffect(() => {
+    localStorage.setItem("sortOption", sortOption);
+  }, [sortOption]);
 
   /** 
   React.useEffect(() => {

--- a/src/TemplatesManager.ts
+++ b/src/TemplatesManager.ts
@@ -1,6 +1,9 @@
 /* eslint-disable curly */
 /* eslint-disable @typescript-eslint/quotes */
 /* eslint-disable prettier/prettier */
+/* eslint-disable curly */
+/* eslint-disable @typescript-eslint/quotes */
+/* eslint-disable prettier/prettier */
 import { ContentsManager } from "@jupyterlab/services";
 import { Template } from "./types";
 
@@ -54,7 +57,6 @@ export class TemplatesManager {
         }
         this.templates.push(template);
         this.activeTemplateHighlightIds.add(template.id);
-        console.log("Active template highlight IDs:", this.activeTemplateHighlightIds);
 
         this.contentsManager.save(`/snippets/${template.name}.json`, {
             type: "file",

--- a/src/TemplatesManager.ts
+++ b/src/TemplatesManager.ts
@@ -1,3 +1,6 @@
+/* eslint-disable curly */
+/* eslint-disable @typescript-eslint/quotes */
+/* eslint-disable prettier/prettier */
 import { ContentsManager } from "@jupyterlab/services";
 import { Template } from "./types";
 
@@ -14,6 +17,8 @@ export class TemplatesManager {
     
     /** JupyterLab's ContentsManager to handle file operations */
     contentsManager : ContentsManager;
+
+    activeTemplateHighlightIds: Set<string> = new Set();
 
     /**
      * Initializes a new instance of the TemplatesManager
@@ -49,7 +54,8 @@ export class TemplatesManager {
             color: '#FFE694',  // Default color
         }
         this.templates.push(template);
-        
+        this.activeTemplateHighlightIds.add(template.id);
+
         this.contentsManager.save(`/snippets/${template.name}.json`, {
             type: "file",
             format: "text",
@@ -79,6 +85,10 @@ export class TemplatesManager {
         // Delete the corresponding JSON file
         this.contentsManager.delete(`/snippets/${template.name}.json`).then(() => {
             console.log(`Successfully deleted template ${template.name} ${templateId}`);
+            document.dispatchEvent(new CustomEvent('TemplateDeleted', {
+              detail: { templateID: templateId}
+                }));
+
         }).catch(( error : unknown ) => {
             console.error(`Failed to delete template ${template.name} ${templateId}`, error);
         })
@@ -151,8 +161,35 @@ export class TemplatesManager {
             console.error("Error updating template content", error);
           });
       }
+    /** Purpose generate a random color for the specific template and 
+     * its corresponding snippets */
+    RandomColor() {
+      const letters = '0123456789ABCDEF';
+      let color = '#';
+      for (let i = 0; i < 6; i++) {
+        color += letters[Math.floor(Math.random() * 16)];
+      }
+      return color;
+     }
 
-      /**
+    /**This is to add whether or not the snippet is on or off when 
+     * first created it should be on
+     * therefore adding it to template color which makes it be on and if toggled off then deleted from list */ 
+    toggleTemplateColor = (id: string) => {
+      if (this.activeTemplateHighlightIds.has(id)) {
+        this.activeTemplateHighlightIds.delete(id); // turn OFF
+      } else {
+        this.activeTemplateHighlightIds.add(id); // turn ON
+      }  
+      // Dispatch an event to notify the editor to update decorations
+     document.dispatchEvent(new CustomEvent('Toggle Template Highlight', {
+       detail: { templateId: id }
+      }));
+    }
+ 
+
+
+     /**
        * Loads all templates from the filesystem into memory
        * 
        * Used to initialize or refresh the templates array using the persisted JSON files.

--- a/src/TemplatesManager.ts
+++ b/src/TemplatesManager.ts
@@ -42,7 +42,6 @@ export class TemplatesManager {
      * 2. Adds the template to the in-memory array
      * 3. Persists the template as a JSON file in the /snippets directory
      */
-    
     create( codeSnippet : string ){
         const template : Template = {
             id: `${Date.now()}`,  // Use timestamp as unique ID
@@ -51,10 +50,11 @@ export class TemplatesManager {
             dateCreated: new Date(),
             dateUpdated: new Date(),
             tags: [],
-            color: '#FFE694',  // Default color
+            color: this.RandomColor(),  // Default color
         }
         this.templates.push(template);
         this.activeTemplateHighlightIds.add(template.id);
+        console.log("Active template highlight IDs:", this.activeTemplateHighlightIds);
 
         this.contentsManager.save(`/snippets/${template.name}.json`, {
             type: "file",
@@ -65,8 +65,8 @@ export class TemplatesManager {
         }).catch(error => {
             console.error("Error saving file", error);
         });
-
         // TODO: May need to call this.update() to refresh the widget state
+        return template;
     }
 
     /**

--- a/src/TemplatesManager.ts
+++ b/src/TemplatesManager.ts
@@ -57,6 +57,7 @@ export class TemplatesManager {
         }
         this.templates.push(template);
         this.activeTemplateHighlightIds.add(template.id);
+        console.log("Active template highlight IDs:", this.activeTemplateHighlightIds);
 
         this.contentsManager.save(`/snippets/${template.name}.json`, {
             type: "file",

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ function activate( app: JupyterFrontEnd , restorer: ILayoutRestorer, extensions:
 
   const contentsManager = new ContentsManager();
   const templatesManager = new TemplatesManager(contentsManager);
-  const snippetsManager = new SnippetsManager(contentsManager);
+  const snippetsManager = new SnippetsManager(contentsManager, templatesManager);
   const libraryWidget = new LibraryWidget(templatesManager, snippetsManager);
   const synchronization = new Synchronization(templatesManager, snippetsManager, libraryWidget);
   libraryWidget.id = "jupyterlab-librarywidget-sidebarRight";

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,15 +104,16 @@ function activate( app: JupyterFrontEnd , restorer: ILayoutRestorer, extensions:
    */
   commands.addCommand('templates:create', {
     label: 'Save Code Snippet',
-    execute: () => {
+    execute: async () => {
       const snippet : string = window.getSelection()?.toString() || '';
       if (snippet){
         console.log("Saving the snippet");
-        libraryWidget.createTemplate(snippet);
-        //give me the template ID and export it too
+        const template = await libraryWidget.createTemplate(snippet);
+
         document.dispatchEvent(new CustomEvent('Save Code Snippet', {
-          detail: { snippetText: snippet,
-            templateID: `${Date.now()}` // Use timestamp as unique ID
+          detail: {
+            snippetText: snippet,
+            templateID: template.id
           }
         }));
         console.log("Event Listener Dispatched!!!");

--- a/src/snippetManager.ts
+++ b/src/snippetManager.ts
@@ -1,5 +1,11 @@
+/* eslint-disable prefer-const */
+/* eslint-disable eqeqeq */
+/* eslint-disable curly */
+/* eslint-disable @typescript-eslint/quotes */
+/* eslint-disable prettier/prettier */
 import { RangeSetBuilder } from '@codemirror/state';
 import { ContentsManager } from "@jupyterlab/services";
+import { TemplatesManager } from './TemplatesManager';
 import { Snippet } from "./types";
 import {
   Decoration,
@@ -21,15 +27,24 @@ export class SnippetsManager {
   public snippetTracker: Snippet[]; /** Array to keep track of all active snippets */
   public cellMap: Map<EditorView, number>; /** Map to associate editor views with their unique cell IDs */
   //private contentsManager : ContentsManager;
-  
+  public activeTemplateID: string | null = null; /** Currently active template ID, if any */
+  private templatesManager : TemplatesManager;
   /**
    * Initializes a new instance of the SnippetsManager
    */
-  constructor( contentsManager : ContentsManager ){
+  constructor( contentsManager : ContentsManager, templates : TemplatesManager ){
     this.snippetTracker = [];
     this.cellMap = new Map();
     this.cellCounter = 0;
+    this.templatesManager = templates;
     //this.contentsManager = contentsManager;
+    /**Purpose: If the template is deleted it will call deleteSnippets */
+    document.addEventListener('TemplateDeleted', (event: Event) => {
+    const customEvent = event as CustomEvent;
+    const templateID = customEvent.detail.templateID;
+
+    this.deleteSnippetsByTemplate(templateID);
+  });
   }
 
 
@@ -74,6 +89,26 @@ export class SnippetsManager {
     }
     console.log("Snippet object being created: ", snippet);
     this.snippetTracker.push(snippet);
+  }
+
+  /**
+   * Deletes all snippets associated with a specific template ID
+   * 
+   * @param templateID - The ID of the template whose snippets should be deleted
+   * 
+   * This method filters the snippetTracker to remove all snippets that match the given template ID.
+   */
+
+  deleteSnippetsByTemplate(templateID: string) {
+    this.snippetTracker = this.snippetTracker.filter(snippet => {
+      const keep = snippet.template_id !== templateID;
+      if (!keep) {
+        console.log(`Removed snippet for template ID: ${templateID}`);
+      }
+      return keep;
+    });
+
+    console.log(`Snippets remaining after delete:`, this.snippetTracker);
   }
 
   /**
@@ -127,12 +162,9 @@ export class SnippetsManager {
           snippet.start_line = start_line;
           snippet.end_line = end_line;
 
-          //TODO: Update contents of the snippets as well, not just their position
           const startPos = newDoc.line(start_line).from;
           const endPos = newDoc.line(end_line).to;
           const updatedSnippet = newDoc.sliceString(startPos, endPos);
-          console.log("Snippet OLD", snippet.content);
-          console.log("Snippet NEW", updatedSnippet);
           snippet.content = updatedSnippet;
 
           console.log("Updated Snippet content", {
@@ -161,54 +193,58 @@ export class SnippetsManager {
 * - Implement different color schemes for dark and light editor modes
 * 
  */
-assignDecorations(view: EditorView): DecorationSet {
-  const cellID = this.cellMap.get(view);
-  if (!cellID) return Decoration.none;
+  assignDecorations(view: EditorView): DecorationSet {
+    const cellID = this.cellMap.get(view);
+    if (!cellID) return Decoration.none;
 
-  const builder = new RangeSetBuilder<Decoration>();
-  
-  //organizes it in order otherwise program will crash
-  const snippetsInCell = this.snippetTracker
-  .filter(s => s.cell_id === cellID)
-  .sort((a, b) => a.start_line - b.start_line);
-
-  //goes through the snippetTracker and checks startline/endline for each
-  for (const snippet of snippetsInCell) {
-    const startLine = view.state.doc.line(snippet.start_line);
-    const endLine = view.state.doc.line(snippet.end_line);
+    const builder = new RangeSetBuilder<Decoration>();
     
-    // Remove empty snippets (where start line equals end line)
-    if (startLine == endLine) {
-      continue;
-    }
+    //organizes it in order otherwise program will crash
+    //FIX THE TEMPLATES MANAGER ADD IT??
+    const snippetsInCell = this.snippetTracker
+    .filter(s => s.cell_id === cellID)
+    .filter(s => this.templatesManager.activeTemplateHighlightIds.has(s.template_id))
+    .sort((a, b) => a.start_line - b.start_line);
 
-    // Apply borders to snippet start & end, currently using pink (#FFC0CB)
-    builder.add(startLine.from, startLine.from, Decoration.line({
-        attributes: { 
-          style: `border-top: 2px solid #FFC0CB; border-left: 2px solid #FFC0CB; border-right: 2px solid #FFC0CB;`,
-          class: 
-          'snippet-start-line',
-          'data-snippet-id': snippet.cell_id.toString(), // Store snippet ID as data attribute, as well as start and end lines
-          'data-start-line': snippet.start_line.toString(),
-          'data-end-line': snippet.end_line.toString(),
-          'data-associated-template': snippet.template_id.toString()
-         },
-      })
-    );
-  
-    builder.add(endLine.from, endLine.from, Decoration.line({
-        attributes: { 
-          style: `border-bottom: 2px solid #FFC0CB; border-left: 2px solid #FFC0CB; border-right: 2px solid #FFC0CB;`,
-          class: 
-          'snippet-end-line',
-          'data-snippet-id': snippet.cell_id.toString() // Store snippet ID as data attribute
-        },
-      })
-    );
+    //goes through the snippetTracker and checks startline/endline for each
+    for (const snippet of snippetsInCell) {
+      const startLine = view.state.doc.line(snippet.start_line);
+      const endLine = view.state.doc.line(snippet.end_line);
+      
+      // Remove empty snippets (where start line equals end line)
+      if (startLine == endLine) {
+        continue;
+      }
+      const template = this.templatesManager.get(snippet.template_id);
+      const borderColor = template ? template.color : undefined;
+
+      // Apply borders to snippet start & end, currently using pink (#FFC0CB)
+      builder.add(startLine.from, startLine.from, Decoration.line({
+          attributes: { 
+            style: `border-top: 2px solid ${borderColor}; border-left: 2px solid ${borderColor}; border-right: 2px solid ${borderColor};`,
+            class: 
+            'snippet-start-line',
+            'data-snippet-id': snippet.cell_id.toString(), // Store snippet ID as data attribute, as well as start and end lines
+            'data-start-line': snippet.start_line.toString(),
+            'data-end-line': snippet.end_line.toString(),
+            'data-associated-template': snippet.template_id.toString()
+          },
+        })
+      );
+    
+      builder.add(endLine.from, endLine.from, Decoration.line({
+          attributes: { 
+            style: `border-bottom: 2px solid ${borderColor}; border-left: 2px solid ${borderColor}; border-right: 2px solid ${borderColor};`,
+            class: 
+            'snippet-end-line',
+            'data-snippet-id': snippet.cell_id.toString() // Store snippet ID as data attribute
+          },
+        })
+      );
+    }
+    
+    return builder.finish();
   }
-  
-  return builder.finish();
-}
 
   /**
    * Loads snippets from persistent storage

--- a/src/snippetManager.ts
+++ b/src/snippetManager.ts
@@ -27,7 +27,6 @@ export class SnippetsManager {
   public snippetTracker: Snippet[]; /** Array to keep track of all active snippets */
   public cellMap: Map<EditorView, number>; /** Map to associate editor views with their unique cell IDs */
   //private contentsManager : ContentsManager;
-  public activeTemplateID: string | null = null; /** Currently active template ID, if any */
   private templatesManager : TemplatesManager;
   /**
    * Initializes a new instance of the SnippetsManager
@@ -199,12 +198,16 @@ export class SnippetsManager {
 
     const builder = new RangeSetBuilder<Decoration>();
     
-    //organizes it in order otherwise program will crash
-    //FIX THE TEMPLATES MANAGER ADD IT??
+    console.log("snippetTracker: CHECKKK", this.snippetTracker);
+    console.log("cellID: ", this.templatesManager.activeTemplateHighlightIds);
+    //Issue here is that snippetsInCell does not have have the the save snippet in here 
     const snippetsInCell = this.snippetTracker
     .filter(s => s.cell_id === cellID)
     .filter(s => this.templatesManager.activeTemplateHighlightIds.has(s.template_id))
     .sort((a, b) => a.start_line - b.start_line);
+
+    console.log("Snippets in cell:", snippetsInCell);
+    console.log("active template highlight IDs:", this.templatesManager.activeTemplateHighlightIds);
 
     //goes through the snippetTracker and checks startline/endline for each
     for (const snippet of snippetsInCell) {

--- a/src/snippetManager.ts
+++ b/src/snippetManager.ts
@@ -203,12 +203,16 @@ export class SnippetsManager {
 
     const builder = new RangeSetBuilder<Decoration>();
     
-    //organizes it in order otherwise program will crash
-    //FIX THE TEMPLATES MANAGER ADD IT??
+    console.log("snippetTracker: CHECKKK", this.snippetTracker);
+    console.log("cellID: ", this.templatesManager.activeTemplateHighlightIds);
+    //Issue here is that snippetsInCell does not have have the the save snippet in here 
     const snippetsInCell = this.snippetTracker
     .filter(s => s.cell_id === cellID)
     .filter(s => this.templatesManager.activeTemplateHighlightIds.has(s.template_id))
     .sort((a, b) => a.start_line - b.start_line);
+
+    console.log("Snippets in cell:", snippetsInCell);
+    console.log("active template highlight IDs:", this.templatesManager.activeTemplateHighlightIds);
 
     //goes through the snippetTracker and checks startline/endline for each
     for (const snippet of snippetsInCell) {

--- a/src/snippetManager.ts
+++ b/src/snippetManager.ts
@@ -3,6 +3,11 @@
 /* eslint-disable curly */
 /* eslint-disable @typescript-eslint/quotes */
 /* eslint-disable prettier/prettier */
+/* eslint-disable prefer-const */
+/* eslint-disable eqeqeq */
+/* eslint-disable curly */
+/* eslint-disable @typescript-eslint/quotes */
+/* eslint-disable prettier/prettier */
 import { RangeSetBuilder } from '@codemirror/state';
 import { ContentsManager } from "@jupyterlab/services";
 import { TemplatesManager } from './TemplatesManager';
@@ -198,16 +203,12 @@ export class SnippetsManager {
 
     const builder = new RangeSetBuilder<Decoration>();
     
-    console.log("snippetTracker: CHECKKK", this.snippetTracker);
-    console.log("cellID: ", this.templatesManager.activeTemplateHighlightIds);
-    //Issue here is that snippetsInCell does not have have the the save snippet in here 
+    //organizes it in order otherwise program will crash
+    //FIX THE TEMPLATES MANAGER ADD IT??
     const snippetsInCell = this.snippetTracker
     .filter(s => s.cell_id === cellID)
     .filter(s => this.templatesManager.activeTemplateHighlightIds.has(s.template_id))
     .sort((a, b) => a.start_line - b.start_line);
-
-    console.log("Snippets in cell:", snippetsInCell);
-    console.log("active template highlight IDs:", this.templatesManager.activeTemplateHighlightIds);
 
     //goes through the snippetTracker and checks startline/endline for each
     for (const snippet of snippetsInCell) {


### PR DESCRIPTION
# Pull Request Template
Pulled template from [here](https://bepieter.medium.com/cracking-github-pr-templates-your-guide-to-skyrocketing-collaboration-bef3d5659241)

## Adding the toggle feature to hide or show decorations
[Provide a succinct and descriptive title for the pull request, e.g., "Improve caching mechanism for API calls"]

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
New button added in the library, now when you click it it will toggle the color it gets put into a list and then gotten rid of when it is turned off and added back in when turned on. I also added delete snippet so that when the templates are deleted they delete the border + doesnt track the lines of the corresponding snippets.

## Testing
[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]

## Impact
Able to toggle and able to delete snippets

## Additional Information
Its a bit buggy the layout so when the library view the icons look too smushed together
## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings 
