### PR TITLE
Templates appear in library once created (without refresh)

### DIFF
--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -8,6 +8,10 @@
    "outputs": [],
    "source": [
     "print(\"trevor\")\n",
+    "\n",
+    "print(\"hi\")\n",
+    "\n",
+    "print(\"lala\")\n",
     "\n"
    ]
   }

--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -12,7 +12,14 @@
     "print(\"hi\")\n",
     "\n",
     "print(\"lala\")\n",
-    "\n"
+    "print(\"L\")\n",
+    "\n",
+    "print(\"y\")\n",
+    "\n",
+    "print(\"bye\")\n",
+    "print(\"oooo\")\n",
+    "\n",
+    "print(\"H\")"
    ]
   }
  ],

--- a/src/LibraryWidget.tsx
+++ b/src/LibraryWidget.tsx
@@ -40,7 +40,6 @@ function Library({ templates, snippets, deleteTemplate, renameTemplate, editTemp
   const initialSortOption = localStorage.getItem("sortOption") || "created-desc";
   const [sortOption, setSortOption] = useState(initialSortOption);
   const [sortedTemplates, setSortedTemplates] = useState<Template[]>(templates);
-  const [sortOption, setSortOption] = useState<string>('created-desc'); // Default to sort by most recently created
 
   const toggleTemplate = (id: string) => {
     setExpandedTemplates((prev) => ({

--- a/src/TemplatesManager.ts
+++ b/src/TemplatesManager.ts
@@ -45,7 +45,7 @@ export class TemplatesManager {
      * 2. Adds the template to the in-memory array
      * 3. Persists the template as a JSON file in the /snippets directory
      */
-    create( codeSnippet : string ){
+    async create( codeSnippet : string ){
         const template : Template = {
             id: `${Date.now()}`,  // Use timestamp as unique ID
             name: `Template ${this.templates.length + 1}`,  // Auto-generate name based on count
@@ -59,17 +59,19 @@ export class TemplatesManager {
         this.activeTemplateHighlightIds.add(template.id);
         console.log("Active template highlight IDs:", this.activeTemplateHighlightIds);
 
-        this.contentsManager.save(`/snippets/${template.name}.json`, {
+        // saving a file should be asynchronous
+        try {
+          await this.contentsManager.save(`/snippets/${template.name}.json`, {
             type: "file",
             format: "text",
             content: JSON.stringify(template,null,2)
-        }).then(() => {
-            console.log(`Saved ${template.name} to file successfully.`);
-        }).catch(error => {
-            console.error("Error saving file", error);
-        });
-        // TODO: May need to call this.update() to refresh the widget state
-        return template;
+          });
+          console.log(`Saved ${template.name} to file successfully.`);
+          return template;
+        }
+        catch(error) {
+          console.error("Error saving file", error);
+        }
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ function activate( app: JupyterFrontEnd , restorer: ILayoutRestorer, extensions:
           console.log("Event Listener Dispatched!!!");
         }
         else {
-        console.error("Template creation failed.")
+          console.error("Template creation failed.")
         }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import { IEditorExtensionRegistry } from '@jupyterlab/codemirror'; // Interface 
  * @param extensions extensions - The registry for CodeMirror editor extensions
  */
 function activate( app: JupyterFrontEnd , restorer: ILayoutRestorer, extensions: IEditorExtensionRegistry) {
-  console.log("real drag and drop cursor fix");
+  console.log("perhaps perhaps");
   const { commands } = app;
 
   const contentsManager = new ContentsManager();
@@ -106,17 +106,22 @@ function activate( app: JupyterFrontEnd , restorer: ILayoutRestorer, extensions:
     label: 'Save Code Snippet',
     execute: async () => {
       const snippet : string = window.getSelection()?.toString() || '';
-      if (snippet){
+      if (snippet) {
         console.log("Saving the snippet");
         const template = await libraryWidget.createTemplate(snippet);
-
-        document.dispatchEvent(new CustomEvent('Save Code Snippet', {
-          detail: {
-            snippetText: snippet,
-            templateID: template.id
-          }
-        }));
-        console.log("Event Listener Dispatched!!!");
+        
+        if (template) {
+          document.dispatchEvent(new CustomEvent('Save Code Snippet', {
+            detail: {
+              snippetText: snippet,
+              templateID: template.id
+            }
+          }));
+          console.log("Event Listener Dispatched!!!");
+        }
+        else {
+        console.error("Template creation failed.")
+        }
       }
     },
   }); 

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,12 +190,12 @@ function activate( app: JupyterFrontEnd , restorer: ILayoutRestorer, extensions:
   app.contextMenu.addItem({
     command: 'templates:push',
     selector: '.jp-FileEditor',
-    rank : 2
+    rank : 1
   });
   app.contextMenu.addItem({
     command: 'templates:push',
     selector: '.jp-Notebook',
-    rank: 2
+    rank: 1
   });
 
 


### PR DESCRIPTION
# Pull Request Template
Pulled template from [here](https://bepieter.medium.com/cracking-github-pr-templates-your-guide-to-skyrocketing-collaboration-bef3d5659241)

## Templates appear in library once created (without refresh)

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
LibraryWidget.tsx: Changed createTemplate() to be async, await TemplateManager.create(), and return the template.
TemplatesManager.ts: Changed create() to be async because saving a file should be an async operation.
index.ts: Added if(template) block to make sure we could access template.id. Added an console.error message if template creation fails. Changed rank of push button to be 1 so it is listed immediately after Save Code Snippet.

## Testing
Tested template creation in the browser.

## Impact
TemplatesManager.create() is now async so any function that calls it needs to await it (and also be async).

## Additional Information
[Any additional information that reviewers should be aware of.]

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings 
